### PR TITLE
Allow polling to be forced on

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,13 @@ in your project's root directory.  You'll get a server listening on port 8080 (b
 
 You can use command-line options to change the behavior a bit as follows:
 
-    $ mr-sparkle [--pattern regex] [--full-reload-pattern regex] [-- [unicorn options]]
+    $ mr-sparkle [--pattern regex] [--full-reload-pattern regex] [--force-polling] [-- [unicorn options]]
 
 Use `--pattern` to replace the default regex that files must match to trigger a reload.  I've tried to make the default fairly liberal--it includes all extensions registered with [tilt](https://github.com/rtomayko/tilt/), for instance--so for most apps it will probably work fine.
 
 Use `--full-reload-pattern` to trigger a full reload for a different set of files.  By default it only does this for `Gemfile.`
+
+Use `--force-polling` to use polling, rather than using file system events. This is useful if you have mounted the files over NFS, in which case events don't work. By default this is turned off.
 
 Any arguments after the `--` will be passed on to unicorn.  This is how you would change the default port, make it not bind to external ip addresses, use a rackup file with a name other than `config.ru`, etc.  See [the unicorn documentation](http://unicorn.bogomips.org/unicorn_1.html) for exactly what you can pass here.  Do not pass the `-c` option to unicorn--`mr-sparkle` comes with its own unicorn config file that it will use automatically.
 

--- a/bin/mr-sparkle
+++ b/bin/mr-sparkle
@@ -14,6 +14,11 @@ OptionParser.new do |opts|
     "By default:\n #{Mr::Sparkle::DEFAULT_FULL_RELOAD_PATTERN.to_s}") do |rx|
     options[:full] = rx
   end
+  opts.on("--force-polling",
+    "Force polling if events aren't working (eg your directory is mounted with NFS).  " +
+    "Default: false") do |rx|
+    options[:force_polling]
+  end
 end.parse!
 
 Mr::Sparkle::Daemon.new.run(options, ARGV)

--- a/bin/mr-sparkle
+++ b/bin/mr-sparkle
@@ -17,7 +17,7 @@ OptionParser.new do |opts|
   opts.on("--force-polling",
     "Force polling if events aren't working (eg your directory is mounted with NFS).  " +
     "Default: false") do |rx|
-    options[:force_polling]
+    options[:force_polling] = rx
   end
 end.parse!
 

--- a/lib/mr-sparkle.rb
+++ b/lib/mr-sparkle.rb
@@ -19,8 +19,9 @@ module Mr
       def run(options, unicorn_args)
         reload_pattern = options[:pattern] || DEFAULT_RELOAD_PATTERN
         full_reload_pattern = options[:full] || DEFAULT_FULL_RELOAD_PATTERN
+        force_polling = options[:force_polling] || false
         @unicorn_args = unicorn_args
-        listener = Listen.to(Dir.pwd, :relative_paths=>true)
+        listener = Listen.to(Dir.pwd, :relative_paths=>true, :force_polling=>force_polling)
         listener.filter(full_reload_pattern)
         listener.filter(reload_pattern)
         listener.change do |modified, added, removed|


### PR DESCRIPTION
The Listen library will fall back to using polling if events are unavailable, but if you have mounted the files over NFS, and are editing them remotely, then file system events are not fired, so the reloading doesn't work.
