### PR TITLE
Should tell bundler to load the gems in the group defined in the RACK_ENV environment variable

### DIFF
--- a/lib/mr-sparkle/unicorn.conf.rb
+++ b/lib/mr-sparkle/unicorn.conf.rb
@@ -4,5 +4,5 @@ GC.respond_to?(:copy_on_write_friendly=) and GC.copy_on_write_friendly = true
 
 before_fork do |server, worker|
   require 'bundler'
-  Bundler.require(:default)
+  Bundler.require(:default, ENV["RACK_ENV"])
 end


### PR DESCRIPTION
This allows me to load my development gems, pry etc. This is the rails behaviour and I'm sure many people are replicating it in their sinatra setups.
